### PR TITLE
Add the possibility to specify an author to the posts

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -10,7 +10,7 @@ layout: default
   </div>
 
   <div class="date">
-    Written on {{ page.date | date: "%B %e, %Y" }}
+    Written on {{ page.date | date: "%B %e, %Y" }} {% if page.author %} by {{ page.author }} {% endif %}
   </div>
 
   {% include disqus.html %}

--- a/_posts/2015-07-08-Hello.md
+++ b/_posts/2015-07-08-Hello.md
@@ -4,6 +4,7 @@ title: Hello world
 permalink: /hello/
 tags: hello, world
 category: hello_world
+author: Onefootball
 ---
 
 We're up and running!


### PR DESCRIPTION
Simplest possibility for now, see
http://frontedgedigital.com/posts/managing-multiple-authors-with-jekyll/
for something fancy.

@dirkaholic @makarski @vberistain If that's ok I propose we simply sign by team name for now
